### PR TITLE
Datasets page metadata section

### DIFF
--- a/app/[id]/datasets.scss
+++ b/app/[id]/datasets.scss
@@ -90,3 +90,29 @@
 .app-date-table__header {
   width: 120px;
 }
+
+.app-metadata-table__header {
+  width: 360px;
+}
+
+.app-metadata-table__header,
+.app-metadata-table__cell {
+  @include govuk-media-query($until: desktop) {
+    border-bottom-width: 0;
+  }
+}
+
+.app-metadata-table__header--visible,
+.app-metadata-table__cell--visible {
+  display: none;
+  @include govuk-media-query($from: desktop) {
+    display: table-cell;
+  }
+}
+
+.app-metadata-table__cell--mobile-visible {
+  display: table-cell;
+  @include govuk-media-query($from: desktop) {
+    display: none;
+  }
+}

--- a/app/[id]/page.tsx
+++ b/app/[id]/page.tsx
@@ -4,6 +4,51 @@ import PhaseBanner from "@/components/PhaseBanner";
 import { getDatasetWithSpatialCoverageInfo } from "../../libs/dataRequests";
 import Image from "next/image";
 
+const metadata = [
+  {
+    field: "Statistical geography",
+    type: "String",
+    description:
+      "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam id neque at ex accumsan dictum at non tellus. Fusce sagittis, ligula eu condimentum commodo, magna nisi cursus mi, ut sagittis orci elit id orci.",
+  },
+  {
+    field: "Measure type",
+    type: "String",
+    description:
+      "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam id neque at ex accumsan dictum at non tellus. Fusce sagittis, ligula eu condimentum commodo, magna nisi cursus mi, ut sagittis orci elit id orci.",
+  },
+  {
+    field: "Gregorian time interval",
+    type: "Date/Time",
+    description:
+      "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam id neque at ex accumsan dictum at non tellus. Fusce sagittis, ligula eu condimentum commodo, magna nisi cursus mi, ut sagittis orci elit id orci.",
+  },
+  {
+    field: "Pupils eligible for free school meals with persistent absences",
+    type: "String",
+    description:
+      "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam id neque at ex accumsan dictum at non tellus. Fusce sagittis, ligula eu condimentum commodo, magna nisi cursus mi, ut sagittis orci elit id orci.",
+  },
+  {
+    field: "Unit of measure",
+    type: "String",
+    description:
+      "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam id neque at ex accumsan dictum at non tellus. Fusce sagittis, ligula eu condimentum commodo, magna nisi cursus mi, ut sagittis orci elit id orci.",
+  },
+  {
+    field: "Upper confidence interval",
+    type: "String",
+    description:
+      "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam id neque at ex accumsan dictum at non tellus. Fusce sagittis, ligula eu condimentum commodo, magna nisi cursus mi, ut sagittis orci elit id orci.",
+  },
+  {
+    field: "Lower confidence interval",
+    type: "String",
+    description:
+      "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam id neque at ex accumsan dictum at non tellus. Fusce sagittis, ligula eu condimentum commodo, magna nisi cursus mi, ut sagittis orci elit id orci.",
+  },
+];
+
 export default async function Datasets({ params }: { params: { id: string } }) {
   const dataset = await getDatasetWithSpatialCoverageInfo(params.id);
   function formatDate(date: string) {
@@ -245,6 +290,59 @@ export default async function Datasets({ params }: { params: { id: string } }) {
               <h2 className="govuk-heading-m">Download dataset</h2>
             </div>
           </div>
+          <section>
+            <h1 className="govuk-heading-l" id="about">
+              Structural metadata
+            </h1>
+            <table className="govuk-table">
+              <thead className="govuk-table__head">
+                <tr className="govuk-table__row">
+                  <th scope="col" className="govuk-table__header">
+                    Field
+                  </th>
+                  <th scope="col" className="govuk-table__header">
+                    Datatype
+                  </th>
+                  <th
+                    scope="col"
+                    className="govuk-table__header app-metadata-table__header--visible"
+                  >
+                    Description
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="govuk-table__body">
+                {metadata.map((item) => {
+                  return (
+                    <>
+                      <tr className="govuk-table__row">
+                        <th
+                          scope="row"
+                          className="govuk-table__header app-metadata-table__header"
+                        >
+                          {item.field}
+                        </th>
+                        <td className="govuk-table__cell app-metadata-table__cell">
+                          {item.type}
+                        </td>
+                        <td className="govuk-table__cell app-metadata-table__cell--visible">
+                          {item.description}
+                        </td>
+                      </tr>
+                      <tr className="govuk-table__row">
+                        <td
+                          colSpan={2}
+                          className="govuk-table__cell app-metadata-table__cell--mobile-visible"
+                        >
+                          {item.description}
+                        </td>
+                      </tr>
+                    </>
+                  );
+                })}
+              </tbody>
+            </table>
+          </section>
         </main>
       </div>
     </>

--- a/app/[id]/page.tsx
+++ b/app/[id]/page.tsx
@@ -290,7 +290,7 @@ export default async function Datasets({ params }: { params: { id: string } }) {
               <h2 className="govuk-heading-m">Download dataset</h2>
             </div>
           </div>
-          <section>
+          <section className="govuk-!-margin-top-7">
             <h1 className="govuk-heading-l" id="about">
               Structural metadata
             </h1>


### PR DESCRIPTION
This ticket is to add the metadata section to the datasets page. Figma [here](https://www.figma.com/file/VhBb6aSrNkKSUv9iY1aZm2/Data-Explorer-MVP?type=design&node-id=11-3238&mode=design&t=gcAPguNjMKqkf0h2-0).

Metadata section is only pulling from a temp local json.

You will need to add three variables to the `.env.local` file, give me a message on slack if you need the username/password
```
NEXT_PUBLIC_BACKEND_URL=https://staging.idpd.uk
NEXT_PRIVATE_USERNAME=***
NEXT_PRIVATE_PASSWORD=***
```