### PR TITLE
Datasets page data preview section

### DIFF
--- a/app/[id]/datasets.scss
+++ b/app/[id]/datasets.scss
@@ -116,3 +116,9 @@
     display: none;
   }
 }
+
+.app-preview-table {
+  border: 1px solid govuk-colour("mid-grey");
+  padding: govuk-spacing(2) govuk-spacing(4) 0 govuk-spacing(4);
+  overflow-x: auto;
+}

--- a/app/[id]/page.tsx
+++ b/app/[id]/page.tsx
@@ -49,6 +49,84 @@ const metadata = [
   },
 ];
 
+const data = [
+  {
+    field: "Statistical Geography",
+    values: [
+      "North East",
+      "North East",
+      "England",
+      "County Durham",
+      "England",
+      "North East",
+      "Darlington",
+      "Darlington",
+      "England",
+      "England",
+    ],
+  },
+  {
+    field: "Measure type",
+    values: [
+      "Pupils eligible for free school meals with persistent absences",
+      "Pupils eligible for free school meals with persistent absences",
+      "Pupils eligible for free school meals with persistent absences",
+      "Pupils eligible for free school meals with persistent absences",
+      "Pupils eligible for free school meals with persistent absences",
+      "Pupils eligible for free school meals with persistent absences",
+      "Pupils eligible for free school meals with persistent absences",
+      "Pupils eligible for free school meals with persistent absences",
+      "Pupils eligible for free school meals with persistent absences",
+      "Pupils eligible for free school meals with persistent absences",
+    ],
+  },
+  {
+    field: "Gregorian time interval",
+    values: [
+      "2017-08-01T00:00:00/P1Y",
+      "2017-08-01T00:00:00/P1Y",
+      "2017-08-01T00:00:00/P1Y",
+      "2017-08-01T00:00:00/P1Y",
+      "2017-08-01T00:00:00/P1Y",
+      "2017-08-01T00:00:00/P1Y",
+      "2017-08-01T00:00:00/P1Y",
+      "2017-08-01T00:00:00/P1Y",
+      "2017-08-01T00:00:00/P1Y",
+      "2017-08-01T00:00:00/P1Y",
+    ],
+  },
+  {
+    field: "Pupils eligible for free school meals with persistent absences",
+    values: [
+      "21.20165",
+      "23.01075",
+      "23.20222",
+      "39.96234",
+      "20.56852",
+      "quarter/2011-Q1",
+      "quarter/2022-Q3",
+      "quarter/2012-Q1",
+      "quarter/2019-Q2",
+      "quarter/2015-Q1",
+    ],
+  },
+  {
+    field: "Location",
+    values: [
+      "England and Wales",
+      "England and Wales",
+      "England and Wales",
+      "England and Wales",
+      "England and Wales",
+      "England and Wales",
+      "England and Wales",
+      "England and Wales",
+      "England and Wales",
+      "England and Wales",
+    ],
+  },
+];
+
 export default async function Datasets({ params }: { params: { id: string } }) {
   const dataset = await getDatasetWithSpatialCoverageInfo(params.id);
   function formatDate(date: string) {
@@ -291,7 +369,42 @@ export default async function Datasets({ params }: { params: { id: string } }) {
             </div>
           </div>
           <section className="govuk-!-margin-top-7">
-            <h1 className="govuk-heading-l" id="about">
+            <h1 className="govuk-heading-l" id="preview">
+              Data preview
+            </h1>
+            <div className="app-preview-table">
+              <table className="govuk-table">
+                <thead className="govuk-table__head">
+                  <tr className="govuk-table__row">
+                    {data.map((item) => {
+                      return (
+                        <th scope="col" className="govuk-table__header">
+                          {item.field}
+                        </th>
+                      );
+                    })}
+                  </tr>
+                </thead>
+                <tbody className="govuk-table__body">
+                  {data[0].values.map((item, index) => {
+                    return (
+                      <tr className="govuk-table__row">
+                        {data.map((item) => {
+                          return (
+                            <td className="govuk-table__cell">
+                              {item.values[index]}
+                            </td>
+                          );
+                        })}
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          </section>
+          <section className="govuk-!-margin-top-7">
+            <h1 className="govuk-heading-l" id="metadata">
               Structural metadata
             </h1>
             <table className="govuk-table">

--- a/app/[id]/page.tsx
+++ b/app/[id]/page.tsx
@@ -386,13 +386,13 @@ export default async function Datasets({ params }: { params: { id: string } }) {
                   </tr>
                 </thead>
                 <tbody className="govuk-table__body">
-                  {data[0].values.map((item, index) => {
+                  {data[0].values.map((_, rowIndex) => {
                     return (
-                      <tr className="govuk-table__row">
-                        {data.map((item) => {
+                      <tr key={rowIndex} className="govuk-table__row">
+                        {data.map((item, colIndex) => {
                           return (
-                            <td className="govuk-table__cell">
-                              {item.values[index]}
+                            <td key={colIndex} className="govuk-table__cell">
+                              {item.values[rowIndex]}
                             </td>
                           );
                         })}


### PR DESCRIPTION
This ticket is to add the data preview section to the datasets page. Figma [here](https://www.figma.com/file/VhBb6aSrNkKSUv9iY1aZm2/Data-Explorer-MVP?type=design&node-id=11-3238&mode=design&t=gcAPguNjMKqkf0h2-0).

Data preview section is only pulling from a temp local json.

You will need to add three variables to the `.env.local` file, give me a message on slack if you need the username/password
```
NEXT_PUBLIC_BACKEND_URL=https://staging.idpd.uk
NEXT_PRIVATE_USERNAME=***
NEXT_PRIVATE_PASSWORD=***
```