### PR TITLE
only download what we need

### DIFF
--- a/libs/dataRequests.tsx
+++ b/libs/dataRequests.tsx
@@ -13,7 +13,7 @@ async function getCsvPreview(url: string): Promise<string[][]> {
     let result = await reader.read();
     let csvData = '';
 
-    while (!result.done && csvData.split('\n').length <= 10) {
+    while (!result.done && csvData.split("\n").length <= 10) {
       csvData += new TextDecoder().decode(result.value, { stream: true });
       result = await reader.read();
     }
@@ -22,7 +22,7 @@ async function getCsvPreview(url: string): Promise<string[][]> {
     const lines = csvData.split('\n').slice(0, 10);
 
     // Parse each line into an array of values
-    const data = lines.map((line: string) => line.split(','));
+    const data = lines.map((line: string) => line.split(","));
 
     return data;
   } catch (error) {

--- a/libs/dataRequests.tsx
+++ b/libs/dataRequests.tsx
@@ -6,24 +6,27 @@ const PASSWORD = process.env.NEXT_PRIVATE_PASSWORD;
 const BACKEND_URL = process.env.NEXT_PUBLIC_BACKEND_URL;
 
 async function getCsvPreview(url: string): Promise<string[][]> {
-  /*
-    Get a 10 line preview of a csv arranged as an
-    array of arrays.
-  */
-
   try {
     const response = await fetchData(url, "GET", "text/csv");
-    const csvData = await response.text();
+
+    const reader = response.body.getReader();
+    let result = await reader.read();
+    let csvData = '';
+
+    while (!result.done && csvData.split('\n').length <= 10) {
+      csvData += new TextDecoder().decode(result.value, { stream: true });
+      result = await reader.read();
+    }
 
     // Split the CSV data into lines
-    const lines = csvData.split("\n").slice(0, 10); // Get the first 10 lines
+    const lines = csvData.split('\n').slice(0, 10);
 
     // Parse each line into an array of values
-    const data = lines.map((line: string) => line.split(","));
+    const data = lines.map((line: string) => line.split(','));
 
     return data;
   } catch (error) {
-    throw error; // You can throw an error for handling it in the caller
+    throw error;
   }
 }
 

--- a/libs/dataRequests.tsx
+++ b/libs/dataRequests.tsx
@@ -19,7 +19,7 @@ async function getCsvPreview(url: string): Promise<string[][]> {
     }
 
     // Split the CSV data into lines
-    const lines = csvData.split('\n').slice(0, 10);
+    const lines = csvData.split("\n").slice(0, 10);
 
     // Parse each line into an array of values
     const data = lines.map((line: string) => line.split(","));


### PR DESCRIPTION
Update the function that powers the csv preview so that it only reads the first 10 lines (previously it read the whole file then took the 10 lines).

Not too noticable on the stub, but when I tried to change over to pulling the full csvs from the google bucket (one of which is 250MB) it got _very_ noticeable.