### PR TITLE
department border

### DIFF
--- a/app/[id]/datasets.scss
+++ b/app/[id]/datasets.scss
@@ -54,24 +54,36 @@
   margin-bottom: 8px;
 }
 
-.app-datasets__publisher {
+.app-datasets-list__item-bottom-publisher {
   align-items: flex-start;
   display: flex;
   flex: 0 0 auto;
   height: min-content;
   overflow: visible;
-
   flex-flow: column;
   gap: govuk-spacing(2);
-
   padding: 0px 0px 0px govuk-spacing(3);
   margin-bottom: govuk-spacing(4);
   position: relative;
-
   border-color: govuk-colour("blue");
   border-style: solid;
   border-width: 0px 0px 0px 5px;
 }
+
+.app-datasets-list__item-bottom-publisher--no_border {
+  padding: 0px 0px 4px 0px;
+  border-width: 0px;
+}
+
+.app-datasets-list__item-publisher-inner {
+  font-size: 18px;
+  font-weight: 400;
+  letter-spacing: 0px;
+  margin-top: govuk-spacing(0);
+  margin-bottom: govuk-spacing(0);
+  font-family: "Helvetica Neue";
+}
+
 
 .app-datasets__publisher-text {
   @include govuk-font($size: 19);

--- a/app/[id]/datasets.scss
+++ b/app/[id]/datasets.scss
@@ -65,9 +65,8 @@
   padding: 0px 0px 0px govuk-spacing(3);
   margin-bottom: govuk-spacing(4);
   position: relative;
-  border-color: govuk-colour("blue");
   border-style: solid;
-  border-width: 0px 0px 0px 5px;
+  border-width: 0px 0px 0px 2px;
 }
 
 .app-datasets-list__item-bottom-publisher--no_border {

--- a/app/[id]/datasets.scss
+++ b/app/[id]/datasets.scss
@@ -71,7 +71,7 @@
 }
 
 .app-datasets-list__item-bottom-publisher--no_border {
-  padding: 0px 0px 4px 0px;
+  padding: 0px;
   border-width: 0px;
 }
 
@@ -83,7 +83,6 @@
   margin-bottom: govuk-spacing(0);
   font-family: "Helvetica Neue";
 }
-
 
 .app-datasets__publisher-text {
   @include govuk-font($size: 19);

--- a/app/[id]/page.tsx
+++ b/app/[id]/page.tsx
@@ -24,7 +24,9 @@ export default async function Datasets({ params }: { params: { id: string } }) {
   const metadata = latestVersion.table_schema.columns;
 
   // Get the email from dataset, removing 'mailto:' prefix if present
-  const contactEmail = dataset.contact_point.email ? dataset.contact_point.email.replace(/^mailto:/i, "") : "";
+  const contactEmail = dataset.contact_point.email
+    ? dataset.contact_point.email.replace(/^mailto:/i, "")
+    : "";
 
   // Get a 10 lines preview of the csv asociated with this version
   const csvData = await getCsvPreview(latestVersion.download_url);
@@ -105,7 +107,10 @@ export default async function Datasets({ params }: { params: { id: string } }) {
               </h1>
               <div className="govuk-body">
                 <h3 className="govuk-heading-s">Publisher</h3>
-                <PublisherComponent title={publisher.title} />
+                <PublisherComponent
+                  title={publisher.title}
+                  id={dataset.publisher}
+                />
                 <a className="govuk-link" href="#">
                   View more datasets by this publisher
                 </a>
@@ -165,14 +170,15 @@ export default async function Datasets({ params }: { params: { id: string } }) {
                 <h3 className="govuk-heading-s">Topics and subtopics</h3>
 
                 {dataset.topics.map((url: string) => {
-                  const segments = url.split('/');
+                  const segments = url.split("/");
                   const lastSegment = segments[segments.length - 1];
-                  const displayText = lastSegment.replace(/-/g, ' ');
+                  const displayText = lastSegment.replace(/-/g, " ");
 
                   return (
                     <div className="govuk-body" key={lastSegment}>
-                      <a className="govuk-link" href={'/' + lastSegment}>
-                        {displayText.charAt(0).toUpperCase() + displayText.slice(1)}
+                      <a className="govuk-link" href={"/" + lastSegment}>
+                        {displayText.charAt(0).toUpperCase() +
+                          displayText.slice(1)}
                       </a>
                     </div>
                   );

--- a/utils/logoCompDict.tsx
+++ b/utils/logoCompDict.tsx
@@ -1,6 +1,7 @@
 import Image from "next/image";
 
 interface LogoProps {
+  id: string;
   title: string;
 }
 
@@ -17,8 +18,11 @@ const checkTitle = (title: string) => {
 
 const createLogoComponent =
   (src: string) =>
-  ({ title }: LogoProps) => {
+  ({ title, id }: LogoProps) => {
     const shouldDisplay = checkTitle(title);
+    const publisher = id.split("/").pop();
+    const colour = govukColoursOrganisations[publisher || ""];
+
     return (
       <div
         className={`app-datasets-list__item-bottom-publisher ${
@@ -26,7 +30,7 @@ const createLogoComponent =
             ? ""
             : "app-datasets-list__item-bottom-publisher--no_border"
         }`}
-        style={{backgroundColor: }}
+        style={{ borderRightColor: colour?.colour }}
       >
         <Image
           src={src}
@@ -34,7 +38,7 @@ const createLogoComponent =
           width={0}
           height={0}
           sizes="100vw"
-          style={{ width: "auto", height: 34 }} // optional
+          style={{ width: "auto", height: 34 }}
         />
         {shouldDisplay && (
           <h3 className="app-datasets-list__item-publisher-inner">{title}</h3>
@@ -59,3 +63,136 @@ const logoCompDict: LogoCompDict = {
 };
 
 export default logoCompDict;
+
+const govukColoursOrganisations: {
+  [id: string]: { colour: string; colourWebsafe?: string };
+} = {
+  "attorney-generals-office": {
+    colour: "#9f1888",
+    colourWebsafe: "#a03a88",
+  },
+  "cabinet-office": {
+    colour: "#005abb",
+    colourWebsafe: "#347da4",
+  },
+  "civil-service": {
+    colour: "#af292e",
+  },
+  "department-for-business-innovation-skills": {
+    colour: "#003479",
+    colourWebsafe: "#347da4",
+  },
+  "department-for-communities-and-local-government": {
+    colour: "#009999",
+    colourWebsafe: "#37836e",
+  },
+  "department-for-culture-media-sport": {
+    colour: "#d40072",
+    colourWebsafe: "#a03155",
+  },
+  "department-for-education": {
+    colour: "#003a69",
+    colourWebsafe: "#347ca9",
+  },
+  "department-for-environment-food-rural-affairs": {
+    colour: "#00a33b",
+    colourWebsafe: "#008938",
+  },
+  "department-for-international-development": {
+    colour: "#002878",
+    colourWebsafe: "#405e9a",
+  },
+  "department-for-international-trade": {
+    colour: "#cf102d",
+    colourWebsafe: "#005ea5",
+  },
+  "department-for-business-and-trade": {
+    colour: "#cf102d",
+    colourWebsafe: "#005ea5",
+  },
+  "department-for-levelling-up-housing-and-communities": {
+    colour: "#012169",
+  },
+  "department-for-transport": {
+    colour: "#006c56",
+    colourWebsafe: "#398373",
+  },
+  "department-for-work-pensions": {
+    colour: "#00beb7",
+    colourWebsafe: "#37807b",
+  },
+  "department-of-energy-climate-change": {
+    colour: "#009ddb",
+    colourWebsafe: "#2b7cac",
+  },
+  "department-of-health": {
+    colour: "#00ad93",
+    colourWebsafe: "#39836e",
+  },
+  "foreign-commonwealth-development-office": {
+    colour: "#012169",
+  },
+  "foreign-commonwealth-office": {
+    colour: "#003e74",
+    colourWebsafe: "#406e97",
+  },
+  "government-equalities-office": {
+    colour: "#9325b2",
+  },
+  "hm-government": {
+    colour: "#0076c0",
+    colourWebsafe: "#347da4",
+  },
+  "hm-revenue-customs": {
+    colour: "#009390",
+    colourWebsafe: "#008670",
+  },
+  "hm-treasury": {
+    colour: "#af292e",
+    colourWebsafe: "#832322",
+  },
+  "home-office": {
+    colour: "#9325b2",
+    colourWebsafe: "#9440b2",
+  },
+  "ministry-of-defence": {
+    colour: "#4d2942",
+    colourWebsafe: "#5a5c92",
+  },
+  "ministry-of-justice": {
+    colour: "#231f20",
+    colourWebsafe: "#5a5c92",
+  },
+  "northern-ireland-office": {
+    colour: "#002663",
+    colourWebsafe: "#3e598c",
+  },
+  "office-of-the-advocate-general-for-scotland": {
+    colour: "#002663",
+    colourWebsafe: "#005ea5",
+  },
+  "office-of-the-leader-of-the-house-of-commons": {
+    colour: "#317023",
+    colourWebsafe: "#005f8f",
+  },
+  "office-of-the-leader-of-the-house-of-lords": {
+    colour: "#9c132e",
+    colourWebsafe: "#c2395d",
+  },
+  "scotland-office": {
+    colour: "#002663",
+    colourWebsafe: "#405c8a",
+  },
+  "uk-export-finance": {
+    colour: "#005747",
+    colourWebsafe: "#005ea5",
+  },
+  "uk-trade-investment": {
+    colour: "#c80651",
+    colourWebsafe: "#005ea5",
+  },
+  "wales-office": {
+    colour: "#a33038",
+    colourWebsafe: "#7a242a",
+  },
+};

--- a/utils/logoCompDict.tsx
+++ b/utils/logoCompDict.tsx
@@ -26,6 +26,7 @@ const createLogoComponent =
             ? ""
             : "app-datasets-list__item-bottom-publisher--no_border"
         }`}
+        style={{backgroundColor: }}
       >
         <Image
           src={src}


### PR DESCRIPTION
This ticket is to change the colour of the border on the publisher component based on department name.
These have been gotten from [here](https://github.com/alphagov/govuk-frontend/blob/main/packages/govuk-frontend/src/govuk/settings/_colours-organisations.scss).
![image](https://github.com/GSS-Cogs/idpd-frontend-datasets/assets/110108574/edc3c76d-5d08-4242-a4e4-18c515eac79b)

**to test**
Currently there is only ONS datasets so some bits of code will be needed to test.
First in utils goto `logoCompDict.tsx` change line 22 to `const shouldDisplay = true`
Then into app/[id] and open `page.tsx`, change line 112 to `id="https://staging.idpd.uk/publishers/department-for-education"`
Boot up and goto `http://localhost:3000/datasets/cpih` you should now see something similar to below.
![image](https://github.com/GSS-Cogs/idpd-frontend-datasets/assets/110108574/3ae83339-6c5b-408e-b095-2e58233e0fa6)

You can change the department to any found at the bottom of the `logoCompDict.tsx` file, and this will change the border colour.
